### PR TITLE
chore: introduce data structure for active integration

### DIFF
--- a/lib/integration/common.ts
+++ b/lib/integration/common.ts
@@ -1,7 +1,9 @@
 import { DateTime } from "luxon";
 import { LOCALE, TIME_ZONE } from "../../config/config";
-import { RezervoSchedule, RezervoWeekSchedule } from "../../types/rezervo";
+import { IntegrationIdentifier, RezervoIntegration, RezervoSchedule, RezervoWeekSchedule } from "../../types/rezervo";
 import { createClassPopularityIndex } from "../popularity";
+import { fetchSitWeekSchedule } from "./sit";
+import { sitToRezervoWeekSchedule } from "./adapters";
 
 export const calculateMondayOffset = () => DateTime.now().setZone(TIME_ZONE).weekday - 1;
 
@@ -68,3 +70,25 @@ export async function fetchRezervoSchedule<T>(
 
     return schedules.reduce((acc, next): RezervoSchedule => ({ ...acc, ...next }), {});
 }
+
+export const activeIntegrations: {
+    // eslint-disable-next-line no-unused-vars
+    [identifier in IntegrationIdentifier]: RezervoIntegration;
+} = {
+    [IntegrationIdentifier.sit]: {
+        name: "Sit Trening",
+        acronym: IntegrationIdentifier.sit,
+        businessUnits: [
+            {
+                name: "Trondheim",
+                weekScheduleFetcher: fetchSitWeekSchedule,
+                weekScheduleAdapter: sitToRezervoWeekSchedule,
+            },
+        ],
+    },
+    [IntegrationIdentifier.fsc]: {
+        name: "Family Sports Club",
+        acronym: IntegrationIdentifier.fsc,
+        businessUnits: [],
+    },
+};

--- a/lib/integration/common.ts
+++ b/lib/integration/common.ts
@@ -4,6 +4,8 @@ import { IntegrationIdentifier, RezervoIntegration, RezervoSchedule, RezervoWeek
 import { createClassPopularityIndex } from "../popularity";
 import { fetchSitWeekSchedule } from "./sit";
 import { sitToRezervoWeekSchedule } from "./adapters";
+import { SitWeekSchedule } from "../../types/integration/sit";
+import { FscWeekSchedule } from "../../types/integration/fsc";
 
 export const calculateMondayOffset = () => DateTime.now().setZone(TIME_ZONE).weekday - 1;
 
@@ -71,9 +73,14 @@ export async function fetchRezervoSchedule<T>(
     return schedules.reduce((acc, next): RezervoSchedule => ({ ...acc, ...next }), {});
 }
 
+export type IntegrationWeekSchedule = {
+    [IntegrationIdentifier.sit]: SitWeekSchedule;
+    [IntegrationIdentifier.fsc]: FscWeekSchedule;
+};
+
 export const activeIntegrations: {
     // eslint-disable-next-line no-unused-vars
-    [identifier in IntegrationIdentifier]: RezervoIntegration;
+    [identifier in IntegrationIdentifier]: RezervoIntegration<IntegrationWeekSchedule[identifier]>;
 } = {
     [IntegrationIdentifier.sit]: {
         name: "Sit Trening",

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,21 +1,29 @@
 import type { NextPage } from "next";
 import React from "react";
-import { fetchSitWeekSchedule } from "../lib/integration/sit";
 import { IntegrationPageProps } from "../types/rezervo";
 import Integration from "../components/Integration";
-import { fetchIntegrationPageStaticProps } from "../lib/integration/common";
-import { sitToRezervoWeekSchedule } from "../lib/integration/adapters";
+import { activeIntegrations, fetchIntegrationPageStaticProps } from "../lib/integration/common";
+
+const integration = activeIntegrations.sit;
 
 export async function getStaticProps(): Promise<{
     revalidate: number;
     props: IntegrationPageProps;
 }> {
-    return await fetchIntegrationPageStaticProps(fetchSitWeekSchedule, sitToRezervoWeekSchedule);
+    const businessUnit = integration.businessUnits[0];
+    if (!businessUnit) {
+        throw new Error(`${integration.name} does not have any business units`);
+    }
+    return await fetchIntegrationPageStaticProps(businessUnit.weekScheduleFetcher, businessUnit.weekScheduleAdapter);
 }
 
 const Index: NextPage<IntegrationPageProps> = ({ initialSchedule, classPopularityIndex }) => {
     return (
-        <Integration initialSchedule={initialSchedule} classPopularityIndex={classPopularityIndex} acronym={"sit"} />
+        <Integration
+            initialSchedule={initialSchedule}
+            classPopularityIndex={classPopularityIndex}
+            acronym={integration.acronym}
+        />
     );
 };
 

--- a/types/rezervo.ts
+++ b/types/rezervo.ts
@@ -67,6 +67,25 @@ export type ClassPopularityIndex = {
     [recurrentId: string]: ClassPopularity;
 };
 
+export enum IntegrationIdentifier {
+    sit = "sit",
+    fsc = "fsc",
+}
+
+export type RezervoIntegration = {
+    name: string;
+    acronym: IntegrationIdentifier;
+    businessUnits: RezervoBusinessUnit[];
+};
+
+export type RezervoBusinessUnit = {
+    name: string;
+    // eslint-disable-next-line no-unused-vars
+    weekScheduleFetcher: (weekNumber: number) => Promise<any>;
+    // eslint-disable-next-line no-unused-vars
+    weekScheduleAdapter: (weekSchedule: any) => RezervoWeekSchedule;
+};
+
 export type RezervoSchedule = { [weekOffset: number]: RezervoWeekSchedule };
 
 export type RezervoWeekSchedule = RezervoDaySchedule[];

--- a/types/rezervo.ts
+++ b/types/rezervo.ts
@@ -72,18 +72,18 @@ export enum IntegrationIdentifier {
     fsc = "fsc",
 }
 
-export type RezervoIntegration = {
+export type RezervoIntegration<T> = {
     name: string;
     acronym: IntegrationIdentifier;
-    businessUnits: RezervoBusinessUnit[];
+    businessUnits: RezervoBusinessUnit<T>[];
 };
 
-export type RezervoBusinessUnit = {
+export type RezervoBusinessUnit<T> = {
     name: string;
     // eslint-disable-next-line no-unused-vars
-    weekScheduleFetcher: (weekNumber: number) => Promise<any>;
+    weekScheduleFetcher: (weekNumber: number) => Promise<T>;
     // eslint-disable-next-line no-unused-vars
-    weekScheduleAdapter: (weekSchedule: any) => RezervoWeekSchedule;
+    weekScheduleAdapter: (weekSchedule: T) => RezervoWeekSchedule;
 };
 
 export type RezervoSchedule = { [weekOffset: number]: RezervoWeekSchedule };


### PR DESCRIPTION
This PR makes /pages agnostic to integration specific data/functions. This is done by introducing a data structure for storing all our active integrations. 