### PR TITLE
fix(linting): remove false positive linting

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -15,5 +15,8 @@ module.exports = {
         browser: true,
         es2022: true,
     },
+    rules: {
+        "no-unused-vars": ["error", { args: "none" }],
+    },
     extends: ["eslint:recommended", "next/core-web-vitals", "prettier"],
 };

--- a/components/modals/Agenda/Agenda.tsx
+++ b/components/modals/Agenda/Agenda.tsx
@@ -12,9 +12,7 @@ export default function Agenda({
     onSetToDelete,
 }: {
     agendaClasses: AgendaClass[];
-    // eslint-disable-next-line no-unused-vars
     onInfo: (c: SitClass) => void;
-    // eslint-disable-next-line no-unused-vars
     onSetToDelete: (cc: ClassConfig, toDelete: boolean) => void;
 }) {
     const theme = useTheme();

--- a/components/modals/Agenda/AgendaClassItem.tsx
+++ b/components/modals/Agenda/AgendaClassItem.tsx
@@ -21,7 +21,6 @@ export default function AgendaClassItem({
     onInfo,
 }: {
     agendaClass: AgendaClass;
-    // eslint-disable-next-line no-unused-vars
     onSetToDelete: (toDelete: boolean) => void;
     onInfo: () => void;
 }) {

--- a/components/modals/Agenda/AgendaModal.tsx
+++ b/components/modals/Agenda/AgendaModal.tsx
@@ -20,7 +20,6 @@ const AgendaModal = ({
     classes: SitClass[];
     selectedClassIds: string[] | null;
     onInfo: Dispatch<SetStateAction<SitClass | null>>;
-    // eslint-disable-next-line no-unused-vars
     onSelectedChanged: (classId: string, selected: boolean) => void;
 }) => {
     return (

--- a/components/schedule/DaySchedule.tsx
+++ b/components/schedule/DaySchedule.tsx
@@ -21,9 +21,7 @@ function DaySchedule({
     selectable: boolean;
     selectedClassIds: string[] | null;
     allConfigsIndex: AllConfigsIndex | null;
-    // eslint-disable-next-line no-unused-vars
     onSelectedChanged: (classId: string, selected: boolean) => void;
-    // eslint-disable-next-line no-unused-vars
     onInfo: (c: SitClass) => void;
 }) {
     const theme = useTheme();

--- a/components/schedule/WeekSchedule.tsx
+++ b/components/schedule/WeekSchedule.tsx
@@ -19,9 +19,7 @@ function WeekSchedule({
     selectable: boolean;
     selectedClassIds: string[] | null;
     allConfigsIndex: AllConfigsIndex | null;
-    // eslint-disable-next-line no-unused-vars
     onSelectedChanged: (classId: string, selected: boolean) => void;
-    // eslint-disable-next-line no-unused-vars
     onInfo: (c: SitClass) => void;
 }) {
     const router = useRouter();

--- a/components/schedule/class/ClassCard.tsx
+++ b/components/schedule/class/ClassCard.tsx
@@ -29,7 +29,6 @@ const ClassCard = ({
     configUsers: UserNameWithIsSelf[];
     selectable: boolean;
     selected: boolean;
-    // eslint-disable-next-line no-unused-vars
     onSelectedChanged: (selected: boolean) => void;
     onInfo: () => void;
     // onSettings: () => void;

--- a/lib/integration/common.ts
+++ b/lib/integration/common.ts
@@ -20,9 +20,7 @@ export const getCapitalizedWeekday = (date: DateTime): string => {
 };
 
 export async function fetchIntegrationPageStaticProps<T>(
-    // eslint-disable-next-line no-unused-vars
     weekScheduleFetcher: (weekOffset: number) => Promise<T>,
-    // eslint-disable-next-line no-unused-vars
     weekScheduleAdapter: (weekSchedule: T) => RezervoWeekSchedule
 ) {
     const initialSchedule = await fetchRezervoSchedule([-1, 0, 1, 2, 3], weekScheduleFetcher, weekScheduleAdapter);
@@ -40,9 +38,7 @@ export async function fetchIntegrationPageStaticProps<T>(
 
 export async function fetchRezervoWeekSchedule<T>(
     weekOffset: number,
-    // eslint-disable-next-line no-unused-vars
     weekScheduleFetcher: (weekOffset: number) => Promise<T>,
-    // eslint-disable-next-line no-unused-vars
     weekScheduleAdapter: (weekSchedule: T) => RezervoWeekSchedule
 ): Promise<RezervoWeekSchedule> {
     const weekSchedule = weekScheduleAdapter(await weekScheduleFetcher(weekOffset));
@@ -57,9 +53,7 @@ export async function fetchRezervoWeekSchedule<T>(
 
 export async function fetchRezervoSchedule<T>(
     weekOffsets: number[],
-    // eslint-disable-next-line no-unused-vars
     weekScheduleFetcher: (weekOffset: number) => Promise<T>,
-    // eslint-disable-next-line no-unused-vars
     weekScheduleAdapter: (weekSchedule: T) => RezervoWeekSchedule
 ): Promise<RezervoSchedule> {
     const schedules = await Promise.all(
@@ -79,7 +73,6 @@ export type IntegrationWeekSchedule = {
 };
 
 export const activeIntegrations: {
-    // eslint-disable-next-line no-unused-vars
     [identifier in IntegrationIdentifier]: RezervoIntegration<IntegrationWeekSchedule[identifier]>;
 } = {
     [IntegrationIdentifier.sit]: {

--- a/types/rezervo.ts
+++ b/types/rezervo.ts
@@ -80,9 +80,7 @@ export type RezervoIntegration<T> = {
 
 export type RezervoBusinessUnit<T> = {
     name: string;
-    // eslint-disable-next-line no-unused-vars
     weekScheduleFetcher: (weekNumber: number) => Promise<T>;
-    // eslint-disable-next-line no-unused-vars
     weekScheduleAdapter: (weekSchedule: T) => RezervoWeekSchedule;
 };
 


### PR DESCRIPTION
Eslint has had some false positives in the linting, where it marks the arguments for functions passed as arguements as unused. This has been the case in the Typescript definitions of the functions that are passed. With this small fix, we ignore this case, since it is clearly a false positive.
For reference:
https://github.com/eslint/eslint/issues/8661#issuecomment-304531311